### PR TITLE
Change API key input from text to password type

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,7 +23,7 @@ class Login extends React.Component {
             <p className="Login__Intro">Enter a Buildkite API Token to get started</p>
             <p className="Login__Extra">The API token needs to have the <code>graphql</code> scope and can be created on your <a href="https://buildkite.com/user/api-access-tokens" target="_blank">API Access Tokens</a> page.</p>
             <form onSubmit={this._onSubmit.bind(this)}>
-              <input type="text" onChange={this._onInputChange.bind(this)} required="true" value={this.state.token} autoFocus="true" />
+              <input type="password" onChange={this._onInputChange.bind(this)} required="true" value={this.state.token} autoFocus="true" />
               <button className="Login__Button">Login</button>
             </form>
           </div>

--- a/css/login.css
+++ b/css/login.css
@@ -43,7 +43,7 @@
   color: #383838;
 }
 
-.Login input[type=text] {
+.Login input[type=password] {
   width: 90%;
   padding: 10px;
   font-size: 20px;


### PR DESCRIPTION
Especially useful if you store your API key in 1password.

Before:

<img width="573" alt="before" src="https://user-images.githubusercontent.com/153/31973654-f3b8953a-b972-11e7-8c6a-a8f2e6f3bde9.png">

After:

<img width="572" alt="after" src="https://user-images.githubusercontent.com/153/31973659-f7733d38-b972-11e7-9e3b-b59505becfdb.png">
